### PR TITLE
Make teleop accelerate faster

### DIFF
--- a/src/main/java/frc/robot/commands/TeleopSwerve.java
+++ b/src/main/java/frc/robot/commands/TeleopSwerve.java
@@ -27,9 +27,9 @@ public class TeleopSwerve extends Command {
   private boolean keepConstantHeading = false;
   private boolean getLastValue = false;
 
-  private static SlewRateLimiter translationLimiter = new SlewRateLimiter(6);
-  private static SlewRateLimiter strafeLimiter = new SlewRateLimiter(6);
-  private static SlewRateLimiter rotationLimiter = new SlewRateLimiter(8 * Math.PI);
+  private static SlewRateLimiter translationLimiter = new SlewRateLimiter(12);
+  private static SlewRateLimiter strafeLimiter = new SlewRateLimiter(12);
+  private static SlewRateLimiter rotationLimiter = new SlewRateLimiter(10 * Math.PI);
 
   private double translationVal;
   private double strafeVal;


### PR DESCRIPTION
The acceleration limiters are causing massive lag in the teleop controls. 

The acceleration limiters are supposed to be a safety net for the driver but they cause way too much control lag. Bumping them up means that safety net is not as present for the driver and the driver may need to be more careful at high speed operations. Driver may need to add their own "acceleration" in how they control the joysticks. 

I tried using a different physics based acceleration limiter that is implemented by path planner but it's too many unknowns to switch to something like that now.