### PR TITLE
Fix small bug in PhotonMoveToTarget and test

### DIFF
--- a/src/main/java/frc/robot/Config.java
+++ b/src/main/java/frc/robot/Config.java
@@ -194,7 +194,10 @@ public final class Config {
       //-(0.865/2 - 0.095) = 0.3375
     //@todo: new 148 deg camera, measured for Apollo
     public static final Transform3d  leftReefCameraTransform = new Transform3d(
-        -0.025, -0.2, 0.72, new Rotation3d(0, Math.toRadians(34.2), Math.toRadians(180)));
+        -0.025, -0.2, 0.72, new Rotation3d(0, Math.toRadians(0), Math.toRadians(180)));
+
+    public static final Transform3d  rightReefCameraTransform = new Transform3d(
+          -0.025, -0.2, 0.72, new Rotation3d(0, Math.toRadians(34.2), Math.toRadians(180)));
 
    
     //networkTableName 
@@ -203,7 +206,7 @@ public final class Config {
     public static final String frontCameraName = "HD_USB_CAMERA";
 
       
-    public static final String leftReefCameraName = "USB_Camera";
+    public static final String leftReefCameraName = "USB_Camera24";
     public static final String rightReefCameraName = "";
     public static final String intakeCameraName = "";
     //data max
@@ -222,7 +225,7 @@ public final class Config {
       //left and right: between center of robot and aprilTag
       //blue reef
       put(17, new Translation2d(1.0, 0));
-      put(18, new Translation2d(1.0, -0.3)); //tested
+      put(18, new Translation2d(0.5, -0.3)); //tested
       put(19, new Translation2d(1.0, 0));
       put(20, new Translation2d(1.0, 0));
       put(21, new Translation2d(-1.0, -0.3)); //tested

--- a/src/main/java/frc/robot/Config.java
+++ b/src/main/java/frc/robot/Config.java
@@ -220,23 +220,28 @@ public final class Config {
     public static final double WAYPOINT_ANGLE_TOLERANCE = Math.toRadians(10.0);
     public static final double VEL_TOLERANCE = 0.1*4;
 
+
+    public static final Translation2d targetOffset = new Translation2d(0.5, 0.3); // From tag coordinate frame, left targets
+    // public static final Translation2d targetOffset = new Translation2d(0.5, -0.3); // From tag coordinate frame, right targets
     public static final Map<Integer,Translation2d> targetOffsetMap =new HashMap<Integer, Translation2d>() {{
-      //all left position. For right, opposite y
-      //left and right: between center of robot and aprilTag
-      //blue reef
-      put(17, new Translation2d(1.0, 0));
-      put(18, new Translation2d(0.5, -0.3)); //tested
-      put(19, new Translation2d(1.0, 0));
-      put(20, new Translation2d(1.0, 0));
-      put(21, new Translation2d(-1.0, -0.3)); //tested
-      put(22, new Translation2d(1.0, 0));
+      // These values are in field oriented coordinates,
+      // So take the tag relative coordinates and rotate them into the field coordinates
+      // The order of tags is in the order of tags around the hexagon, starting from the tag that faces away from the blue allaince 
+      // blue reef
+      put(21, targetOffset.rotateBy(Rotation2d.fromDegrees(60 * 0))); // faces 0
+      put(20, targetOffset.rotateBy(Rotation2d.fromDegrees(60 * 1))); // faces 60 deg
+      put(19, targetOffset.rotateBy(Rotation2d.fromDegrees(60 * 2))); // faces 120 deg
+      put(18, targetOffset.rotateBy(Rotation2d.fromDegrees(60 * 3))); // faces 180 deg
+      put(17, targetOffset.rotateBy(Rotation2d.fromDegrees(60 * 4))); // faces 240 deg
+      put(22, targetOffset.rotateBy(Rotation2d.fromDegrees(60 * 5))); // faces 300 deg
+
       //red reef
-      put(6, new Translation2d(1.0, 0));
-      put(7, new Translation2d(-1.0, -0.3)); //tested
-      put(8, new Translation2d(1.0, 0));
-      put(9, new Translation2d(1.0, 0));
-      put(10, new Translation2d(1.0, 0));
-      put(11, new Translation2d(1.0, 0));
+      put(7, targetOffset.rotateBy(Rotation2d.fromDegrees(60 * 0)));  // faces 0 deg (away from blue alliance is 0 deg)
+      put(8, targetOffset.rotateBy(Rotation2d.fromDegrees(60 * 1)));  // faces 60 deg
+      put(9, targetOffset.rotateBy(Rotation2d.fromDegrees(60 * 2)));  // faces 120 deg
+      put(10, targetOffset.rotateBy(Rotation2d.fromDegrees(60 * 3))); // faces 180 deg (away from red allaince is 180 deg)
+      put(11, targetOffset.rotateBy(Rotation2d.fromDegrees(60 * 4))); // faces 240 deg
+      put(6, targetOffset.rotateBy(Rotation2d.fromDegrees(60 * 5)));  // faces 300 deg
       //blue human station
 
       //red human station

--- a/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
+++ b/src/main/java/frc/robot/commands/PhotonMoveToTarget.java
@@ -7,6 +7,7 @@ package frc.robot.commands;
 //imports
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -72,8 +73,8 @@ public class PhotonMoveToTarget extends Command {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    //+++Translation2d setPoint = PhotonSubsystem.getInstance().getTargetPos();
-    Translation2d setPoint = PhotonSubsystem.getInstance().getNewTargetPos();
+    Translation2d setPoint = PhotonSubsystem.getInstance().getTargetPos();
+    // Translation2d setPoint = PhotonSubsystem.getInstance().getNewTargetPos();
 
     Rotation2d targetRotation = PhotonSubsystem.getInstance().getTargetRotation();
     Rotation2d targetRobotHeading = PhotonSubsystem.getInstance().getTargetRobotHeading();
@@ -82,13 +83,21 @@ public class PhotonMoveToTarget extends Command {
     //rotationSetPoint = current robot heading + yaw. Note yaw needs to keep updating
     //convert to Robot: facing to AprilTag
     Rotation2d rotationSetPoint = Rotation2d.fromDegrees(targetRotation.getDegrees()+180);     
-        
-    if (centerTarget){
-      SwerveSubsystem.getInstance().driveToPose(new Pose2d(setPoint.plus(targetOffset), rotationSetPoint));
-    }else{
-      //use the absolute heading
-      SwerveSubsystem.getInstance().driveToPose(new Pose2d(setPoint.plus(targetOffset), targetRobotHeading));
+
+    Rotation2d desiredRotation;
+    if (centerTarget) {
+      desiredRotation = rotationSetPoint;
+    } else {
+      desiredRotation = targetRobotHeading;
     }
+
+    // Grab the latest target offset.
+    targetOffset = PhotonSubsystem.getInstance().getTargetOffset();
+
+    Pose2d desiredPose = new Pose2d(setPoint, desiredRotation);
+    desiredPose = desiredPose.transformBy(new Transform2d(targetOffset, new Rotation2d()));
+
+    SwerveSubsystem.getInstance().driveToPose(desiredPose);
   }
  
 

--- a/src/main/java/frc/robot/robotcontainers/Robot2025Container.java
+++ b/src/main/java/frc/robot/robotcontainers/Robot2025Container.java
@@ -179,10 +179,16 @@ public class Robot2025Container extends RobotContainer {
 
     //This is good one: press one time: with timer
     //================================================
-    driver.leftTrigger()
-    .onTrue(Commands.sequence(Commands.runOnce(() -> TeleopSwerve.setSpeeds(TeleopSpeeds.VISION)), 
-            CombinedCommands.visionScoreLeftReef(driver, operator).withTimeout(0.9)))
-    .onFalse(Commands.runOnce(() -> TeleopSwerve.setSpeeds(TeleopSpeeds.MAX)));
+    // driver.leftTrigger()
+    // .onTrue(Commands.sequence(Commands.runOnce(() -> TeleopSwerve.setSpeeds(TeleopSpeeds.VISION)), 
+    //         CombinedCommands.visionScoreLeftReef(driver, operator).withTimeout(0.9)))
+    // .onFalse(Commands.runOnce(() -> TeleopSwerve.setSpeeds(TeleopSpeeds.MAX)));
+
+    driver.leftTrigger().onTrue(Commands.runOnce(() -> TeleopSwerve.setSpeeds(TeleopSpeeds.VISION)))
+        .onFalse(Commands.runOnce(() -> TeleopSwerve.setSpeeds(TeleopSpeeds.MAX)));
+    driver.leftTrigger().onTrue(Commands.runOnce(() -> PhotonSubsystem.getInstance().reset())); // Re-acquire target every time button is pressed
+    driver.leftTrigger().and(() -> PhotonSubsystem.getInstance().hasData()) // Run vision command while button is pressed down AND a target is found
+        .whileTrue(new PhotonMoveToTarget(false, false, false));
 
     //Operator
     //===========================================================================

--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -207,10 +207,10 @@ public class SwerveSubsystem extends SubsystemBase {
     field = new Field2d();
     SmartDashboard.putData("Field", field);
 
-    pidControlX = new ProfiledPIDController(9, 0.5, 0.2,
-            new TrapezoidProfile.Constraints(2.5, 4.5));
-    pidControlY = new ProfiledPIDController(9, 0.5, 0.2,
-            new TrapezoidProfile.Constraints(2.5, 4.5));
+    pidControlX = new ProfiledPIDController(7, 0.5, 0.2,
+            new TrapezoidProfile.Constraints(1.5, 2.0));
+    pidControlY = new ProfiledPIDController(7, 0.5, 0.2,
+            new TrapezoidProfile.Constraints(1.5, 2.0));
     pidControlRotation = new ProfiledPIDController(5.0, 0.5, 0.3,
             new TrapezoidProfile.Constraints(8 * Math.PI, 8 * Math.PI));
             pidControlRotation.enableContinuousInput(-Math.PI, Math.PI);


### PR DESCRIPTION
## Describe your changes

- Deduced that the april tag was getting correctly tracked by the PhotonSubsystem
- Deduced that the target offset in PhotonMoveToTarget was not being used correctly
- Fixed PhotonMoveToTarget
- Slowed down swerve driveToPose a little bit
- Updated the camera transform in config to match the way the robot is currently setup. Need re-measure this properly. The current robot has a pitch of 0 but the code had a pitch of ~34.
- Simplified the way the command is scheduled. See Robot2025Container. It's as simple as `driver.leftTrigger().and(() -> PhotonSubsystem.getInstance().hasData().whileTrue(new PhotonMoveToTarget(false, false, false));`

## Testing

- Tested on new robot
- Had to move the apriltag higher to test because the current location just can't see the tag
